### PR TITLE
add NAMESERVER environment variable for nginx dns resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ volumes:
   kratos-sqlite:
 ```
 
+### Optional Environment Variables
+- `NAMESERVER`: the nameserver to use for dns resolution for kratos urls. By default, it reads values from /etc/resolv.conf, so it works well without setting this value in many runtimes. If there is no /etc/resolv.conf, it will be set to `127.0.0.11` (Docker dns).
+
 ## Start local
 
 It is required, that a local instance of ory kratos is running. the latest tested version is `v1.0.0`.

--- a/kratos-admin-ui/deploy/nginx.conf
+++ b/kratos-admin-ui/deploy/nginx.conf
@@ -20,8 +20,7 @@ server {
     listen 80;
 
     location /api/admin/ {
-        # see https://www.emmanuelgautier.com/blog/nginx-docker-dns-resolution
-        resolver 				 127.0.0.11;
+        resolver 				 $NAMESERVER valid=30s;
 
         rewrite /api/admin/(.*) /admin/$1  break;
 
@@ -33,8 +32,7 @@ server {
     }
 
     location /api/public/ {
-        # https://www.emmanuelgautier.com/blog/nginx-docker-dns-resolution
-        resolver 				 127.0.0.11;
+        resolver 				 $NAMESERVER valid=30s;
 
         rewrite /api/public/(.*) /$1  break;
 

--- a/kratos-admin-ui/deploy/start.sh
+++ b/kratos-admin-ui/deploy/start.sh
@@ -1,3 +1,14 @@
+if [ -z ${NAMESERVER+x} ]; then
+    if [ -f /etc/resolv.conf ]; then
+        export NAMESERVER=$(awk '/^nameserver/{print $2}' /etc/resolv.conf)
+    else
+        # see https://www.emmanuelgautier.com/blog/nginx-docker-dns-resolution
+        export NAMESERVER="127.0.0.11"
+    fi
+fi
+
+echo "Nameserver is: $NAMESERVER"
+
 checkFormat() {
     regex="http?(s)://"
     if [ "$1" == $regex* ]; then


### PR DESCRIPTION
Fixes #122

### Expected behavior
The system should resolve the hostname for Kratos in the internal network, applicable not only to Docker locally but also to other container runtimes.
Nginx should prioritize using /etc/resolv.conf, and default to 127.0.0.11 only if this configuration file is unavailable.

### Tests
I have tested following cases:
- [x] docker compose up without customize. admin ui is works well.
- [x] docker compose up with NAMESERVER=127.0.0.1 as env variable. The value of resolver in nginx is configured expectedly. (Of course, admin ui is not working as expectedly). 
- [x] docker compose up with custom resolv.conf(nameserver 10.170.0.20) by mounting file. The value of resolver in nginx is configured expectedly. (Of course, admin ui is not working as expectedly). 